### PR TITLE
Add ability to sort interstitial's forward as well as in reverse.

### DIFF
--- a/source/kara/macros/disp-items-interstitial.tid
+++ b/source/kara/macros/disp-items-interstitial.tid
@@ -4,9 +4,15 @@ type: text/vnd.tiddlywiki
 
 \define kara-disp-items()
 <div class="interstitial" style="display:block;">
-<$list filter="[<displayMode>match[reverse]]" emptyMessage='<$transclude tiddler=<<dblock>> field=title mode=block/>' variable=ignore>
+<$list filter="[<displayMode>regexp[reverse|sort]]" emptyMessage='<$transclude tiddler=<<dblock>> field=title mode=block/>' variable=ignore>
+<$list filter="[<displayMode>match[reverse]]" variable=ignore>
 <$transclude tiddler={{{ [<dblock>splitregexp[\n]!is[blank]trim:prefix[]trim[*]trim:prefix[]!sort[]addprefix[* ]] :and[join<lbr>] }}} field=title mode=block/>
 </$list>
+<$list filter="[<displayMode>match[sort]]" variable=ignore>
+<$transclude tiddler={{{ [<dblock>splitregexp[\n]!is[blank]trim:prefix[]trim[*]trim:prefix[]sort[]addprefix[* ]] :and[join<lbr>] }}} field=title mode=block/>
+</$list>
+</$list>
+
 </div>
 \end
 


### PR DESCRIPTION
Interstitial allows reverse sort, but not forward sort. This adds ability for forward sort.

Please test before merge. I may not know what I'm doing.