### PR TITLE
Add style selector to use interstitial in sidebar.

### DIFF
--- a/source/kara/styles/main.css
+++ b/source/kara/styles/main.css
@@ -6,6 +6,7 @@
 
 /* interstitial section ------------*/
 .tc-tiddler-body ul.interstitial,
+.tc-sidebar-tabs-main ul.interstitial,
 .tc-tiddler-preview-preview ul.interstitial{
 	display:none;
 }


### PR DESCRIPTION
If you use the interstitial check box in the sidebar, it gets duplicated. This adds a style selector to remove the duplicate.